### PR TITLE
Pass error arguments to error handlers.

### DIFF
--- a/src/core/GlobalErrors.js
+++ b/src/core/GlobalErrors.js
@@ -7,7 +7,7 @@ getJasmineRequireObj().GlobalErrors = function(j$) {
       var handler = handlers[handlers.length - 1];
 
       if (handler) {
-        handler.apply(null, Array.prototype.slice.call(arguments, 0));
+        handler.apply(null, Array.prototype.slice.call(arguments));
       } else {
         throw arguments[0];
       }


### PR DESCRIPTION

## Description
Passing only the first argument cripples jasmine in web browser uses.  In the browser the onerror event is passed a funky list of args:
https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror
By slicing only the first arg only get the message, never the lines and most important never the Error object with the call stack.

AFAIK in node the Error object is the sole object sent to the handler so we are no worse off in that case.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

